### PR TITLE
Sort endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-queries.js

--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ app.get('/', (request, response) => {
 
 app.get('/irises', db.getIrises)
 
+app.get('/irises/:class', db.getIrisesByClass)
+
 
 app.listen(port, () => {
   console.log(`App running on port ${port}.`)

--- a/queries.js
+++ b/queries.js
@@ -1,0 +1,33 @@
+const Pool = require('pg').Pool
+const pool = new Pool({
+  user: 'iris_role',
+  host: 'localhost',
+  database: 'irisapp',
+  password: 'password',
+  port: 5432,
+})
+
+const getIrises = (request, response) => {
+  pool.query('SELECT * FROM irises ORDER BY id ASC', (error, results) => {
+    if (error) {
+      throw error
+    }
+    response.status(200).json(results.rows)
+  })
+}
+
+const getIrisesByClass = (request, response) => {
+  pool.query(`SELECT * FROM irises WHERE class=$1 ORDER BY id ASC`,
+              [request.params.class],
+                (error, results) => {
+                  if (error) {
+                    throw error
+                  }
+                  response.status(200).json(results.rows)
+                })
+}
+
+module.exports = {
+  getIrises,
+  getIrisesByClass,
+}


### PR DESCRIPTION
closes #12 
closes #15
adds endpoint for irises to accept query string (class)
issues:
1) this endpoint is not guarded for incorrect user input (anything that's not a class)
2) this is not a RESTful endpoint and needs to be refactored into a non-iris endpoint, maybe one called `search`