### PR TITLE
Refactor iris search

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,8 @@ app.get('/', (request, response) => {
 })
 
 app.get('/irises', db.getIrises)
-app.get('/irises/search/class/:class', db.getIrisesByClass)
-app.get('/irises/search/location/:location', db.getIrisesByLocation)
+app.get('/search/irises/class/:class', db.getIrisesByClass)
+app.get('/search/irises/location/:location', db.getIrisesByLocation)
 
 
 app.listen(port, () => {

--- a/index.js
+++ b/index.js
@@ -16,8 +16,16 @@ app.get('/', (request, response) => {
 })
 
 app.get('/irises', db.getIrises)
+
 app.get('/search/irises/class/:class', db.getIrisesByClass)
+app.get('/search/irises/class', (request, response) => {
+  response.json( { message: `Enter a class name after /search/irises/class/[name here]`})
+})
+
 app.get('/search/irises/location/:location', db.getIrisesByLocation)
+app.get('/search/irises/location', (request, response) => {
+  response.json( { message: `Enter the integer of the location after /search/irises/location/[integer here]`})
+})
 
 
 app.listen(port, () => {

--- a/index.js
+++ b/index.js
@@ -16,8 +16,8 @@ app.get('/', (request, response) => {
 })
 
 app.get('/irises', db.getIrises)
-
-app.get('/irises/:class', db.getIrisesByClass)
+app.get('/irises/search/class/:class', db.getIrisesByClass)
+app.get('/irises/search/location/:location', db.getIrisesByLocation)
 
 
 app.listen(port, () => {

--- a/queries.js
+++ b/queries.js
@@ -27,7 +27,12 @@ const getIrisesByClass = (request, response) => {
                 })
 }
 
+const getIrisesByLocation = (request, response) => {
+  
+}
+
 module.exports = {
   getIrises,
   getIrisesByClass,
+  getIrisesByLocation,
 }

--- a/queries.js
+++ b/queries.js
@@ -28,7 +28,14 @@ const getIrisesByClass = (request, response) => {
 }
 
 const getIrisesByLocation = (request, response) => {
-  
+  pool.query(`SELECT * FROM irises WHERE location=$1 ORDER BY id ASC`,
+              [request.params.location],
+                (error, results) => {
+                  if (error) {
+                    throw error
+                  }
+                  response.status(200).json(results.rows)
+                })
 }
 
 module.exports = {


### PR DESCRIPTION
closes #18 
reorganize two search options to be RESTful
note: explored using query string (?class or ?location) after /search in URL instead of param in differentiated route, this approach would mean a more detailed search function or additional helpers